### PR TITLE
[rfc] 参加クエスト一覧と達成チャレンジ一覧を取得するAPIを作成

### DIFF
--- a/migrations/20230812054910_remove_quest_attributes.sql
+++ b/migrations/20230812054910_remove_quest_attributes.sql
@@ -1,0 +1,4 @@
+ALTER TABLE quests DROP COLUMN price;
+ALTER TABLE quests DROP COLUMN difficulty;
+ALTER TABLE quests DROP COLUMN num_participate;
+ALTER TABLE quests DROP COLUMN num_clear;

--- a/migrations/20230815051920_insert_test_data.sql
+++ b/migrations/20230815051920_insert_test_data.sql
@@ -1,0 +1,277 @@
+INSERT INTO quests VALUES ('testquest', '23区すべての区役所を訪れるスタンプラリー', '東京23区すべての区役所を訪れて東京都マスターになろう！');
+INSERT INTO challenges VALUES (
+  'testchallenge1',
+  '足立区の区役所を訪れる',
+  '足立区役所に行こう！',
+  'testquest',
+  '35.77514494456143',
+  '139.80448866943198',
+  '足立区',
+  'http://localhost:4566/quest-app-images-bucket/adachi_color.png',
+  'http://localhost:4566/quest-app-images-bucket/adachi_monoclo.png',
+  '足立区民（アローラのすがた）'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge2',
+  '荒川区の区役所を訪れる',
+  '荒川区役所に行こう！',
+  'testquest',
+  '35.73636037941233',
+  '139.78324823271583',
+  '荒川区',
+  'http://localhost:4566/quest-app-images-bucket/arakawaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/arakawaku_monoclo.png',
+  '荒川区民にとって荒川はガンジス川である。しかし荒川区に荒川は流れていない'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge3',
+  '文京区の区役所を訪れる',
+  '文京区役所に行こう！',
+  'testquest',
+  '35.70830442633105',
+  '139.75219807806806',
+  '文京区',
+  'http://localhost:4566/quest-app-images-bucket/bunkyoku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/bunkyoku_monoclo.png',
+  '文京区には東京大学があります'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge4',
+  '千代田区の区役所を訪れる',
+  '千代田区役所に行こう！',
+  'testquest',
+  '35.694200612944705',
+  '139.75344659641138',
+  '千代田区',
+  'http://localhost:4566/quest-app-images-bucket/chiyodaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/chiyodaku_monoclo.png',
+  '江戸城ってこんな感じだったのかなぁ...'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge5',
+  '中央区の区役所を訪れる',
+  '中央区役所に行こう！',
+  'testquest',
+  '35.670850770265965',
+  '139.77197223873802',
+  '中央区',
+  'http://localhost:4566/quest-app-images-bucket/chuoku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/chuoku_monoclo.png',
+  '銀座でショッピング！（強盗に注意）'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge6',
+  '江戸川区の区役所を訪れる',
+  '江戸川区役所に行こう！',
+  'testquest',
+  '35.706813076150375',
+  '139.86845918292065',
+  '江戸川区',
+  'http://localhost:4566/quest-app-images-bucket/edogawaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/edogawaku_monoclo.png',
+  'ボートレースしにおいでよ江戸川区'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge7',
+  '板橋区の区役所を訪れる',
+  '板橋区役所に行こう！',
+  'testquest',
+  '35.75127430140424',
+  '139.70951353389958',
+  '板橋区',
+  'http://localhost:4566/quest-app-images-bucket/itabashiku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/itabashiku_monoclo.png',
+  '板橋区はファミリーにとって住みよい町です（すいません、それ以外の魅力は見つかりませんでした）'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge8',
+  '葛飾区の区役所を訪れる',
+  '葛飾区役所に行こう！',
+  'testquest',
+  '35.74369926658082',
+  '139.84721561100466',
+  '葛飾区',
+  'http://localhost:4566/quest-app-images-bucket/katsusikaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/katsusikaku_monoclo.png',
+  'こちら葛飾区'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge9',
+  '北区の区役所を訪れる',
+  '北区役所に行こう！',
+  'testquest',
+  '35.75312261773068',
+  '139.73399779826715',
+  '北区',
+  'http://localhost:4566/quest-app-images-bucket/kitaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/kitaku_monoclo.png',
+  '北区では昼から飲酒する人がマジョリティです'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge10',
+  '江東区の区役所を訪れる',
+  '江東区役所に行こう！',
+  'testquest',
+  '35.6730806171568',
+  '139.8172782099019',
+  '江東区',
+  'http://localhost:4566/quest-app-images-bucket/kotoku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/kotoku_monoclo.png',
+  '江東区ではスケートボードが盛んです'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge11',
+  '目黒区の区役所を訪れる',
+  '目黒区役所に行こう！',
+  'testquest',
+  '35.64153475469307',
+  '139.69816182524548',
+  '目黒区',
+  'http://localhost:4566/quest-app-images-bucket/meguro_color.png',
+  'http://localhost:4566/quest-app-images-bucket/meguro_monoclo.png',
+  'みんな大好き目黒川'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge12',
+  '港区の区役所を訪れる',
+  '港区役所に行こう！',
+  'testquest',
+  '35.658153831924',
+  '139.7514693675736',
+  '港区',
+  'http://localhost:4566/quest-app-images-bucket/minatoku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/minatoku_monoclo.png',
+  '港区といえば東京タワー！（決して六本木・西麻布ではありません）'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge13',
+  '中野区の区役所を訪れる',
+  '中野区役所に行こう！',
+  'testquest',
+  '35.70737592742804',
+  '139.66373358106694',
+  '中野区',
+  'http://localhost:4566/quest-app-images-bucket/nakanoku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/nakanoku_monoclo.png',
+  'サンプラザ中野くんは、日本のミュージシャン、作家。アミューズ所属。「山口のばら」名義で作詞も行っている。身長181cm、体重74kg。血液型はB型。左利き。スキンヘッドとサングラスがトレードマーク。中野裕貴とも。 山梨県甲府市生まれ、千葉県育ち。千葉県立東葛飾高等学校卒業、早稲田大学政治経済学部政治学科除籍。'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge14',
+  '練馬区の区役所を訪れる',
+  '練馬区役所に行こう！',
+  'testquest',
+  '35.735941330803',
+  '139.65172225223205',
+  '練馬区',
+  'http://localhost:4566/quest-app-images-bucket/nerimaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/nerimaku_monoclo.png',
+  '練馬区は23区で一番公園の多い区です'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge15',
+  '大田区の区役所を訪れる',
+  '大田区役所に行こう！',
+  'testquest',
+  '35.56139921803839',
+  '139.7160623982595',
+  '大田区',
+  'http://localhost:4566/quest-app-images-bucket/ootaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/ootaku_monoclo.png',
+  '羽田空港は大田区にあります'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge16',
+  '世田谷区の区役所を訪れる',
+  '世田谷区役所に行こう！',
+  'testquest',
+  '35.64673770624585',
+  '139.65333985408193',
+  '世田谷区',
+  'http://localhost:4566/quest-app-images-bucket/setagayaku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/setagayaku_monoclo.png',
+  '世田谷区民のアフタヌーンティー経験率は60%を超え、アメリカにおける銃所持率を上回っています（要検証）'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge17',
+  '渋谷区の区役所を訪れる',
+  '渋谷区役所に行こう！',
+  'testquest',
+  '35.66382363931477',
+  '139.69774089641004',
+  '渋谷区',
+  'http://localhost:4566/quest-app-images-bucket/shibuya_color.png',
+  'http://localhost:4566/quest-app-images-bucket/shibuya_monoclo.png',
+  '渋谷109'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge18',
+  '品川区の区役所を訪れる',
+  '品川区役所に行こう！',
+  'testquest',
+  '35.609380156988024',
+  '139.730278696408',
+  '品川区',
+  'http://localhost:4566/quest-app-images-bucket/shinagawa_color.png',
+  'http://localhost:4566/quest-app-images-bucket/shinagawa_monoclo.png',
+  '品川から新幹線乗っても自由席空いてない'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge19',
+  '新宿区の区役所を訪れる',
+  '新宿区役所に行こう！',
+  'testquest',
+  '35.694089499789854',
+  '139.70340735408382',
+  '新宿区',
+  'http://localhost:4566/quest-app-images-bucket/shinjuku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/shinjuku_monoclo.png',
+  '新宿区役所は歌舞伎町の中にあります（なんで？）'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge20',
+  '墨田区の区役所を訪れる',
+  '墨田区役所に行こう！',
+  'testquest',
+  '35.710881103208585',
+  '139.80169751175703',
+  '墨田区',
+  'http://localhost:4566/quest-app-images-bucket/skytree_color.png',
+  'http://localhost:4566/quest-app-images-bucket/skytree_monoclo.png',
+  'スカイツリーは墨田区、そして東京の象徴'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge21',
+  '杉並区の区役所を訪れる',
+  '杉並区役所に行こう！',
+  'testquest',
+  '35.69974165307776',
+  '139.6363076233943',
+  '杉並区',
+  'http://localhost:4566/quest-app-images-bucket/suginamiku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/suginamiku_monoclo.png',
+  '杉並区高円寺ではたくさんの路上ミュージシャンがいます。その7割はただブルーハーツを歌っているだけです。'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge22',
+  '台東区の区役所を訪れる',
+  '台東区役所に行こう！',
+  'testquest',
+  '35.712750865115815',
+  '139.7800529982657',
+  '台東区',
+  'http://localhost:4566/quest-app-images-bucket/taitoku_color.png',
+  'http://localhost:4566/quest-app-images-bucket/taitoku_monoclo.png',
+  '台東区の客寄せパンダ'
+);
+INSERT INTO challenges VALUES (
+  'testchallenge23',
+  '豊島区の区役所を訪れる',
+  '豊島区役所に行こう！',
+  'testquest',
+  '35.726384689000575',
+  '139.7167353271024',
+  '豊島区',
+  'http://localhost:4566/quest-app-images-bucket/toshima_color.png',
+  'http://localhost:4566/quest-app-images-bucket/toshimaku_monoclo.png',
+  '豊島区の天空闘技場ことサンシャインシティ'
+);

--- a/src/handlers/user_challenge.rs
+++ b/src/handlers/user_challenge.rs
@@ -2,11 +2,18 @@ use axum::{
     extract::{Extension, Path},
     http::StatusCode,
     response::IntoResponse,
-    Json,
+    Json, TypedHeader,
 };
 use std::sync::Arc;
 
-use crate::repositories::user_challenge::{CompleteChallengePayload, UserChallengeRepository};
+use crate::{
+    repositories::{
+        user_challenge::{CompleteChallengePayload, UserChallengeRepository},
+        user_quest::UserQuestRepository,
+    },
+    services::user::decode_jwt,
+    UserInfoHandlerState,
+};
 
 pub async fn complete_challenge<T: UserChallengeRepository>(
     Path(challenge_id): Path<String>,
@@ -21,14 +28,23 @@ pub async fn complete_challenge<T: UserChallengeRepository>(
     Ok(StatusCode::CREATED)
 }
 
-pub async fn get_completed_challenges<T: UserChallengeRepository>(
-    Path(id): Path<String>,
-    Extension(repository): Extension<Arc<T>>,
+pub async fn get_completed_challenges<T: UserQuestRepository, S: UserChallengeRepository>(
+    TypedHeader(cookie): TypedHeader<axum::headers::Cookie>,
+    Extension(state): Extension<UserInfoHandlerState<T, S>>,
 ) -> Result<impl IntoResponse, StatusCode> {
-    let challenge_id = repository
-        .get_completed_challenges_by_user_id(id)
-        .await
-        .or(Err(StatusCode::NOT_FOUND))?;
+    if let Some(cookie_token) = cookie.get("session_token") {
+        let secret_key = &state.secret_key;
 
-    Ok((StatusCode::OK, Json(challenge_id)))
+        let decoded_token = decode_jwt(cookie_token, &secret_key).unwrap();
+
+        let quest_ids = state
+            .userchallenge_repository
+            .get_completed_challenges_by_user_id(decoded_token.claims.user_id)
+            .await
+            .or(Err(StatusCode::NOT_FOUND))?;
+
+        return Ok((StatusCode::OK, Json(quest_ids)));
+    }
+
+    return Err(StatusCode::UNAUTHORIZED);
 }

--- a/src/handlers/user_challenge.rs
+++ b/src/handlers/user_challenge.rs
@@ -20,3 +20,15 @@ pub async fn complete_challenge<T: UserChallengeRepository>(
 
     Ok(StatusCode::CREATED)
 }
+
+pub async fn get_completed_challenges<T: UserChallengeRepository>(
+    Path(id): Path<String>,
+    Extension(repository): Extension<Arc<T>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let challenge_id = repository
+        .get_completed_challenges_by_user_id(id)
+        .await
+        .or(Err(StatusCode::NOT_FOUND))?;
+
+    Ok((StatusCode::OK, Json(challenge_id)))
+}

--- a/src/handlers/user_challenge.rs
+++ b/src/handlers/user_challenge.rs
@@ -46,5 +46,5 @@ pub async fn get_completed_challenges<T: UserQuestRepository, S: UserChallengeRe
         return Ok((StatusCode::OK, Json(quest_ids)));
     }
 
-    return Err(StatusCode::UNAUTHORIZED);
+    return Ok((StatusCode::OK, Json(Vec::new())));
 }

--- a/src/handlers/user_quest.rs
+++ b/src/handlers/user_quest.rs
@@ -2,11 +2,18 @@ use axum::{
     extract::{Extension, Path},
     http::StatusCode,
     response::IntoResponse,
-    Json,
+    Json, TypedHeader,
 };
 use std::sync::Arc;
 
-use crate::repositories::user_quest::{ParticipateQuestPayload, UserQuestRepository};
+use crate::{
+    repositories::{
+        user_challenge::UserChallengeRepository,
+        user_quest::{ParticipateQuestPayload, UserQuestRepository},
+    },
+    services::user::decode_jwt,
+    UserInfoHandlerState,
+};
 
 pub async fn participate_quest<T: UserQuestRepository>(
     Path(quest_id): Path<String>,
@@ -21,14 +28,23 @@ pub async fn participate_quest<T: UserQuestRepository>(
     Ok(StatusCode::CREATED)
 }
 
-pub async fn get_participated_quests<T: UserQuestRepository>(
-    Path(id): Path<String>,
-    Extension(repository): Extension<Arc<T>>,
+pub async fn get_participated_quests<T: UserQuestRepository, S: UserChallengeRepository>(
+    TypedHeader(cookie): TypedHeader<axum::headers::Cookie>,
+    Extension(state): Extension<UserInfoHandlerState<T, S>>,
 ) -> Result<impl IntoResponse, StatusCode> {
-    let quest_ids = repository
-        .get_participated_quests_by_user_id(id)
-        .await
-        .or(Err(StatusCode::NOT_FOUND))?;
+    if let Some(cookie_token) = cookie.get("session_token") {
+        let secret_key = &state.secret_key;
 
-    Ok((StatusCode::OK, Json(quest_ids)))
+        let decoded_token = decode_jwt(cookie_token, &secret_key).unwrap();
+
+        let quest_ids = state
+            .userquest_repository
+            .get_participated_quests_by_user_id(decoded_token.claims.user_id)
+            .await
+            .or(Err(StatusCode::NOT_FOUND))?;
+
+        return Ok((StatusCode::OK, Json(quest_ids)));
+    }
+
+    return Err(StatusCode::UNAUTHORIZED);
 }

--- a/src/handlers/user_quest.rs
+++ b/src/handlers/user_quest.rs
@@ -46,5 +46,5 @@ pub async fn get_participated_quests<T: UserQuestRepository, S: UserChallengeRep
         return Ok((StatusCode::OK, Json(quest_ids)));
     }
 
-    return Err(StatusCode::UNAUTHORIZED);
+    return Ok((StatusCode::OK, Json(Vec::new())));
 }

--- a/src/handlers/user_quest.rs
+++ b/src/handlers/user_quest.rs
@@ -20,3 +20,15 @@ pub async fn participate_quest<T: UserQuestRepository>(
 
     Ok(StatusCode::CREATED)
 }
+
+pub async fn get_participated_quests<T: UserQuestRepository>(
+    Path(id): Path<String>,
+    Extension(repository): Extension<Arc<T>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let quest_ids = repository
+        .get_participated_quests_by_user_id(id)
+        .await
+        .or(Err(StatusCode::NOT_FOUND))?;
+
+    Ok((StatusCode::OK, Json(quest_ids)))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ mod test {
 
     use crate::repositories::{
         challenge::{Challenge, CreateChallenge},
-        quest::{CreateQuest, Difficulty, QuestEntity},
+        quest::{CreateQuest, QuestEntity},
         user::{RegisterUser, UserEntity},
     };
 
@@ -260,10 +260,6 @@ mod test {
             nanoid!(),
             "Test Create Quest".to_string(),
             "This is a test of creating a quest.".to_string(),
-            0,
-            Difficulty::Normal,
-            12345,
-            123,
         );
 
         let req = build_req_with_json(
@@ -271,11 +267,7 @@ mod test {
             Method::POST,
             r#"{
                 "title": "Test Create Quest",
-                "description": "This is a test of creating a quest.",
-                "price": 0,
-                "difficulty": "Normal",
-                "num_participate": 12345,
-                "num_clear": 123
+                "description": "This is a test of creating a quest."
              }"#
             .to_string(),
         );
@@ -299,20 +291,12 @@ mod test {
             nanoid!(),
             "Test Find Quest".to_string(),
             "This is a test of finding a quest.".to_string(),
-            0,
-            Difficulty::Normal,
-            12345,
-            123,
         );
 
         let created_quest = quest_repository
             .create(CreateQuest::new(
                 "Test Find Quest".to_string(),
                 "This is a test of finding a quest.".to_string(),
-                0,
-                Difficulty::Normal,
-                12345,
-                123,
             ))
             .await
             .expect("failed to create quest");
@@ -338,19 +322,11 @@ mod test {
             nanoid!(),
             "Test All Quests".to_string(),
             "This is a test of finding all quests.".to_string(),
-            0,
-            Difficulty::Normal,
-            12345,
-            123,
         );
         quest_repository
             .create(CreateQuest::new(
                 "Test All Quests".to_string(),
                 "This is a test of finding all quests.".to_string(),
-                0,
-                Difficulty::Normal,
-                12345,
-                123,
             ))
             .await
             .expect("failed to create quest");
@@ -377,19 +353,11 @@ mod test {
             nanoid!(),
             "Test Update Quests".to_string(),
             "This is a test of updating a quest.".to_string(),
-            0,
-            Difficulty::Normal,
-            12345,
-            123,
         );
         let created_quest = quest_repository
             .create(CreateQuest::new(
                 "Test Update Quests Before".to_string(),
                 "This is a dummy quest before updating.".to_string(),
-                0,
-                Difficulty::Normal,
-                12345,
-                123,
             ))
             .await
             .expect("failed to create quest");
@@ -423,10 +391,6 @@ mod test {
             .create(CreateQuest::new(
                 "Test Delete Quests".to_string(),
                 "This is a test of deleting a quest.".to_string(),
-                0,
-                Difficulty::Normal,
-                12345,
-                123,
             ))
             .await
             .expect("failed to create quest");
@@ -590,10 +554,6 @@ mod test {
             .create(CreateQuest::new(
                 "Test Quest".to_string(),
                 "This is a test quest.".to_string(),
-                0,
-                Difficulty::Normal,
-                12345,
-                123,
             ))
             .await
             .unwrap();

--- a/src/repositories/user_challenge.rs
+++ b/src/repositories/user_challenge.rs
@@ -84,7 +84,7 @@ impl UserChallengeRepository for UserChallengeRepositoryForDb {
         .bind(user_id)
         .fetch_all(&self.pool)
         .await
-        .map_err(|_| Vec::<String>::new())
+        .map_err(|_| Vec::<UserChallengeFromRow>::new())
         .unwrap();
 
         let quest_ids = challenges.iter().map(|x| x.challenge_id.clone()).collect();
@@ -96,7 +96,6 @@ impl UserChallengeRepository for UserChallengeRepositoryForDb {
 #[allow(dead_code)]
 #[derive(Debug, Clone, FromRow)]
 struct UserChallengeFromRow {
-    id: i32,
     user_id: String,
     challenge_id: String,
 }

--- a/src/repositories/user_quest.rs
+++ b/src/repositories/user_quest.rs
@@ -83,7 +83,7 @@ impl UserQuestRepository for UserQuestRepositoryForDb {
         .bind(user_id)
         .fetch_all(&self.pool)
         .await
-        .map_err(|_| Vec::<String>::new())
+        .map_err(|_| Vec::<UserQuestFromRow>::new())
         .unwrap();
 
         let quest_ids = quests.iter().map(|x| x.quest_id.clone()).collect();
@@ -95,7 +95,6 @@ impl UserQuestRepository for UserQuestRepositoryForDb {
 #[allow(dead_code)]
 #[derive(Debug, Clone, FromRow)]
 struct UserQuestFromRow {
-    id: i32,
     user_id: String,
     quest_id: String,
 }


### PR DESCRIPTION
- `/me/participated_quests`で参加クエスト一覧を取得する
- `/me/completed_challenges`で達成チャレンジ一覧を取得する
- それぞれのテストを追加

`rfc/remove-unnecessary-attributes-breakdown/remove-unncessary-members`ブランチを切って作成