### PR TITLE
[bug fix]Dockerfileの修正

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 COPY . .
 
 # sqlx-cliツールをインストール
-RUN cargo install sqlx-cli cargo-watch
+RUN cargo install --locked sqlx-cli cargo-watch
 
 # 依存関係をビルドし、キャッシュを利用する
 RUN cargo build --release

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,5 +1,5 @@
 # ベースイメージを指定
-FROM rust:1.68
+FROM rust:1.73
 
 # 作業ディレクトリを設定
 WORKDIR /usr/src/app
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 COPY . .
 
 # sqlx-cliツールをインストール
-RUN cargo install --locked sqlx-cli cargo-watch
+RUN cargo install sqlx-cli cargo-watch
 
 # 依存関係をビルドし、キャッシュを利用する
 RUN cargo build --release


### PR DESCRIPTION
## Issue

`make build`すると以下のようなエラーが出てイメージのビルドに失敗する
```
#8 230.4 error: failed to compile `sqlx-cli v0.7.1`, intermediate artifacts can be found at `/tmp/cargo-installTPgv6w`
#8 230.4 
#8 230.4 Caused by:
#8 230.4   package `clap_complete v4.4.1` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.68.2
#8 230.4   Try re-running cargo install with `--locked`
#8 230.4      Summary Successfully installed cargo-watch! Failed to install sqlx-cli (see error(s) above).
#8 230.4 error: some crates failed to install
------
executor failed running [/bin/sh -c cargo install sqlx-cli cargo-watch]: exit code: 101
ERROR: Service 'api' failed to build : Build failed
make: *** [build] Error 1
```

`sqlx-cli`をインストールする際に`rustc`のバージョンと合わないらしい

## Fix

エラーメッセージの通り`--locked`フラッグをつけてインストールする。
（てかRustのイメージをバージョンアップする方でもいいかも、特に今のversionにこだわる理由無さそうだし）