### PR TITLE
[fix]コンテナのNameを明示的に指定する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ migrate:
 	docker-compose exec api sqlx migrate run --ignore-missing
 
 seed:
-	docker cp ./seeds/seed.sql quest-api_database_1:/tmp/
-	docker exec quest-api_database_1 psql -U $(DATABASE_USER) -d $(DATABASE_DB) -q -f /tmp/seed.sql
+	docker cp ./seeds/seed.sql quest-database-container:/tmp/
+	docker exec quest-database-container psql -U $(DATABASE_USER) -d $(DATABASE_DB) -q -f /tmp/seed.sql
 
 start: up migrate seed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   database:
+    container_name: quest-database-container
     build:
       context: .
       dockerfile: ./docker/db/Dockerfile
@@ -16,6 +17,7 @@ services:
       TZ: Asia/Tokyo
     restart: always
   api:
+    container_name: quest-api-container
     build:
       context: .
       dockerfile: ./docker/web/Dockerfile


### PR DESCRIPTION
## Issue

今までは`docker-compose`でコンテナたちを立ち上げるときにコンテナ名を指定していなかった。
しかし、`docker-compose`のバージョンの違いによって、自動的に付けられる名前が異なることが判明。

### 例

- 古いversionのDocker Desktopでは`app_database_1`のようにアンダースコアが用いられる
- 新しいversionのDocker Desktopでは`app-database-1`のようにハイフンが用いられる
- cf
  - https://docs.docker.com/desktop/release-notes/#for-all-platforms-46 

## Fix

`docker-compose.yml`で明示的に`container_name`を指定する